### PR TITLE
Move signup request to an api route

### DIFF
--- a/web/api-client/errors.ts
+++ b/web/api-client/errors.ts
@@ -1,0 +1,3 @@
+export interface ErrorWithMessage {
+  message: string;
+}

--- a/web/api-client/errors.ts
+++ b/web/api-client/errors.ts
@@ -1,3 +1,13 @@
+import { AxiosError } from "axios";
+
 export interface ErrorWithMessage {
   message: string;
 }
+
+// Only good for errors from our own API from axios requests
+export const getErrorMessage = (
+  error: Error,
+  defaultMessage: string = "An unknown error occurred"
+) => {
+  return (error as AxiosError)?.response?.data?.message ?? defaultMessage;
+};

--- a/web/api-client/signup.ts
+++ b/web/api-client/signup.ts
@@ -1,0 +1,13 @@
+import axios from "axios";
+
+export interface SignupRequest {
+  email: string;
+}
+
+// The same fore now
+export type SignupResponse = SignupRequest;
+
+export const sendSignup = async (request: SignupRequest) => {
+  const response = await axios.post("/api/signup", request);
+  return response.data as SignupResponse;
+};

--- a/web/api-utilities/send-error.ts
+++ b/web/api-utilities/send-error.ts
@@ -1,0 +1,14 @@
+import { NextApiResponse } from "next";
+import { ErrorWithMessage } from "../api-client/errors";
+
+export const sendError = (
+  res: NextApiResponse<ErrorWithMessage>,
+  status: number,
+  message: string
+) => {
+  if (status < 400) {
+    throw new Error(`bad error status: ${status}`);
+  }
+  res.statusMessage = message;
+  return res.status(status).json({ message });
+};

--- a/web/package.json
+++ b/web/package.json
@@ -16,6 +16,7 @@
     "@sanity/block-content-to-react": "^2.0.7",
     "@sanity/client": "^2.0.0",
     "@sanity/image-url": "^0.140.19",
+    "axios": "^0.21.0",
     "next": "^10.0.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",

--- a/web/pages/api/signup.ts
+++ b/web/pages/api/signup.ts
@@ -1,0 +1,49 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { ErrorWithMessage } from "../../api-client/errors";
+import { SignupRequest, SignupResponse } from "../../api-client/signup";
+import { sendError } from "../../api-utilities/send-error";
+import client from "../../client";
+
+const addSignupToSanity = async (request: SignupRequest) => {
+  const register = {
+    _type: "signupform",
+    data: {
+      email: request.email,
+    },
+  };
+  return await client.create(register);
+};
+
+/**
+ * Send a POST request to /api/signup with a body
+ * of SignupRequest to signup a user. However,
+ * prefer using sendSignup from api-client/signup
+ * for neatness
+ * */
+export default async (
+  req: NextApiRequest,
+  res: NextApiResponse<SignupResponse | ErrorWithMessage>
+) => {
+  if (req.method !== "POST") {
+    throw new Error("Only accepts POSTs with body of { email: string }");
+  }
+
+  const signupRequest = req.body as SignupRequest;
+
+  if (typeof signupRequest?.email !== "string") {
+    throw new Error("Missing email");
+  }
+
+  try {
+    await addSignupToSanity(signupRequest);
+  } catch (e) {
+    if (e.statusCode === 403) {
+      console.error("Sanity isn't authorized!!");
+      return sendError(res, 500, "Internal auth issue");
+    } else {
+      return sendError(res, 500, "Failed to send to sanity");
+    }
+  }
+
+  res.status(200).json({ email: signupRequest.email });
+};

--- a/web/pages/landing.tsx
+++ b/web/pages/landing.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { getErrorMessage } from "../api-client/errors";
 import { sendSignup, SignupRequest } from "../api-client/signup";
 import { SignUpForm } from "./LandingPage/SignUp.components";
 
@@ -20,7 +21,7 @@ export const SignUp = () => {
       const signupResponse = await sendSignup(signupRequest);
       console.log("signup response", signupResponse);
     } catch (e) {
-      console.error("failed to send signup request", e);
+      setError(getErrorMessage(e));
     }
   };
 

--- a/web/pages/landing.tsx
+++ b/web/pages/landing.tsx
@@ -1,34 +1,42 @@
-import React, { useState } from 'react';
-import { SignUpForm } from './LandingPage/SignUp.components'
-import client from '../client.js';
-
+import React, { useState } from "react";
+import { sendSignup, SignupRequest } from "../api-client/signup";
+import { SignUpForm } from "./LandingPage/SignUp.components";
 
 export const SignUp = () => {
+  const [{ username }, setRegisterData] = useState({
+    username: "",
+  });
 
-  const [{username}, setRegisterData] = useState({
-    username: '',
-  })
-
-  const [error, setError] = useState('')
+  const [error, setError] = useState("");
 
   const handler = async (event: React.FormEvent) => {
     event.preventDefault();
 
-    const register = {
-      _type: 'signupform',
-      data: {
-        email: username
-      }
+    const signupRequest: SignupRequest = {
+      email: username,
+    };
+
+    try {
+      const signupResponse = await sendSignup(signupRequest);
+      console.log("signup response", signupResponse);
+    } catch (e) {
+      console.error("failed to send signup request", e);
     }
-    const result = await client.create(register);
   };
 
   return (
     <SignUpForm onSubmit={handler}>
       <label htmlFor="username"> Email </label>
-      <input value={username} name="username" type="email" onChange={(event) => setRegisterData({
-        username: event.target.value,
-      })} />
+      <input
+        value={username}
+        name="username"
+        type="email"
+        onChange={(event) =>
+          setRegisterData({
+            username: event.target.value,
+          })
+        }
+      />
 
       <button type="submit"> SignUp </button>
       {error.length > 0 && <p>{error}</p>}


### PR DESCRIPTION
Instead of sending the signup request to sanity from the front end, send the sanity request from the back end. This will let us keep sanity auth on the backend, preventing users from being able to access the API key.

New flow summed up:
* user hits submit
* front end sends POST request to /api/signup
* pages/api/signup.ts receives the request and sends a signup request to sanity

Possible next step: 
* Use Next environment variables to store Sanity auth information safely (don't check the config file into git)

Note:
* Switching from Sanity to another service for email signup won't require touching the front end
* Adds axios as a dependency for sending requests (running `npm install` will be necessary after pulling)