### PR TITLE
attempted fix at missing api/uploadFile call

### DIFF
--- a/components/dropzoneComponent.tsx
+++ b/components/dropzoneComponent.tsx
@@ -27,13 +27,13 @@ function DropzoneComponent({ handleDrop }: any) {
   // }, [file])
 
   async function handleImageUpload(e: ChangeEvent<HTMLInputElement>) {
+    e.preventDefault() // need to stop default, which causes form submit
     console.log('handleImageUpload')
     const el = e.target as HTMLInputElement
     if (el.files != null) {
       const file = el.files[0]
       const formData = new FormData()
       formData.append('file', file)
-      // formData.append('id', userId) //FIXME: how to associate file to a user before user is created?
 
       // 1. set state locally, for fileWithPreview preview purposes.
       // const fileWithPreview = {...file, preview: URL.createObjectURL(file)}


### PR DESCRIPTION
My theory is that upload file input "Browse" was triggering form submission, causing the user to be created prematurely, with no works attached. When the form is purposely submitted, the user is detected as a duplicate and errors